### PR TITLE
Fix: Update download-artifact to v4 for compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: srvstat
 


### PR DESCRIPTION
The release step was failing with the error "Error: Missing download info for actions/download-artifact@v3". This was due to an incompatibility between actions/upload-artifact@v4 used in the build job and actions/download-artifact@v3 used in the release job.

This commit updates actions/download-artifact to v4 in the release job to resolve this issue. Artifacts uploaded with v4 of upload-artifact must be downloaded with v4 of download-artifact.